### PR TITLE
Allow pointer argument and return values

### DIFF
--- a/func_test.go
+++ b/func_test.go
@@ -48,6 +48,25 @@ func TestFuncCall(t *testing.T) {
 		},
 
 		{
+			"basic named matching (pointer struct)",
+			func(in *struct {
+				Struct
+
+				A, B int
+			}) int {
+				return in.A + in.B
+			},
+			[]Arg{
+				Named("a", 12),
+				Named("b", 24),
+			},
+			[]interface{}{
+				36,
+			},
+			"",
+		},
+
+		{
 			"basic matching with types",
 			func(in struct {
 				Struct

--- a/func_test.go
+++ b/func_test.go
@@ -538,6 +538,64 @@ func TestFuncCall(t *testing.T) {
 		},
 
 		{
+			"direct named converter (pointer)",
+			func(in struct {
+				Struct
+
+				A string
+			}) string {
+				return in.A + "!"
+			},
+			[]Arg{
+				Named("a", 12),
+				Converter(func(s struct {
+					Struct
+
+					A int
+				}) *struct {
+					Struct
+
+					A string
+				} {
+					return &struct {
+						Struct
+
+						A string
+					}{A: strconv.Itoa(s.A)}
+				}),
+			},
+			[]interface{}{"12!"},
+			"",
+		},
+
+		{
+			"direct named converter (pointer, nil result)",
+			func(in struct {
+				Struct
+
+				A string
+			}) string {
+				return in.A + "!"
+			},
+			[]Arg{
+				Named("a", 12),
+				Converter(func(s struct {
+					Struct
+
+					A int
+				}) *struct {
+					Struct
+
+					A string
+				} {
+					return nil
+				}),
+			},
+			[]interface{}{"!"},
+			"",
+		},
+
+		{
 			"generic type converter",
 			func(in struct {
 				Struct

--- a/struct.go
+++ b/struct.go
@@ -61,6 +61,10 @@ type structInterface interface {
 // isStruct returns true if the given type is a struct that embeds our
 // struct marker.
 func isStruct(t reflect.Type) bool {
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
 	if t.Kind() != reflect.Struct {
 		return false
 	}

--- a/value_set.go
+++ b/value_set.go
@@ -22,8 +22,10 @@ type ValueSet struct {
 	structType reflect.Type
 
 	// structPointers is the number of pointers that wrap structType.
-	// We use this to construct the correct argument type.
-	structPointers uint
+	// We use this to construct the correct argument type. Note we only
+	// support one pointer today, so this will be at most "1" but making it
+	// an int for the future.
+	structPointers uint8
 
 	// values is the set of values that this ValueSet contains. namedValues,
 	// typedValues, etc. are convenience maps for looking up values more
@@ -178,7 +180,7 @@ func newValueSet(count int, get func(int) reflect.Type) (*ValueSet, error) {
 func newValueSetFromStruct(typ reflect.Type) (*ValueSet, error) {
 	// Unwrap any pointers around our struct type and count the number of
 	// pointer derefs. We need to know the count to reconstruct it later.
-	var ptrCount uint
+	var ptrCount uint8
 	for typ.Kind() == reflect.Ptr {
 		typ = typ.Elem()
 		ptrCount++
@@ -414,7 +416,7 @@ func (t *ValueSet) result(r Result) Result {
 	// any pointers. We know this to be true already since we analyzed the
 	// function earlier.
 	if !t.lifted() {
-		for i := uint(0); i < t.structPointers; i++ {
+		for i := uint8(0); i < t.structPointers; i++ {
 			r.out[0] = r.out[0].Elem()
 		}
 
@@ -543,7 +545,7 @@ func (v *structValue) CallIn() []reflect.Value {
 	if !v.typ.lifted() {
 		// We do need to wrap the value in some pointers
 		val := v.value
-		for i := uint(0); i < v.typ.structPointers; i++ {
+		for i := uint8(0); i < v.typ.structPointers; i++ {
 			val = val.Addr()
 		}
 


### PR DESCRIPTION
It is idiomatic Go for argument structs or return values to be pointers and it could be expected that users of argmapper will use this form. An example is shown below.

```go
type myArgs struct {
  argmapper.Struct

  A int
}

func doThing(args *myArgs) {}
```

Prior to this PR, this didn't work (`args *myArgs` had to be `args myArgs`). It seems silly to force this so this PR adds support for pointer arguments. While we're at it, we added support for pointer results too. The behavior of a nil pointer result is the same as a struct with zero values.