### PR TITLE
Dry run mode

### DIFF
--- a/args.go
+++ b/args.go
@@ -29,6 +29,8 @@ type argBuilder struct {
 
 	funcName string
 	funcOnce bool
+
+	dryRun bool
 }
 
 func newArgBuilder(opts ...Arg) (*argBuilder, error) {
@@ -239,6 +241,18 @@ func FuncName(n string) Arg {
 func FuncOnce() Arg {
 	return func(a *argBuilder) error {
 		a.funcOnce = true
+		return nil
+	}
+}
+
+// DryRun causes the target function and any converters to NOT be called.
+// This can be used to ensure that given a set of inputs a function CAN
+// theoretically be called, assuming no converters error in the middle. This
+// is a good way to test that all inputs can reach the target arguments for
+// the target function.
+func DryRun() Arg {
+	return func(a *argBuilder) error {
+		a.dryRun = true
 		return nil
 	}
 }

--- a/func_test.go
+++ b/func_test.go
@@ -1150,6 +1150,85 @@ func TestFuncCall(t *testing.T) {
 			[]interface{}{"1"},
 			"",
 		},
+
+		//----------------------------------------------------------------
+		// DryRun
+
+		{
+			"dry run with only target",
+			func(in struct {
+				Struct
+
+				A, B int
+			}) int {
+				panic("YOU CALLED ME!")
+			},
+			[]Arg{
+				Named("a", 12),
+				Named("b", 24),
+				DryRun(),
+			},
+			[]interface{}{
+				0, // the zero value
+			},
+			"",
+		},
+
+		{
+			"dry run with missing arg",
+			func(in struct {
+				Struct
+
+				A, B int
+			}) int {
+				panic("YOU CALLED ME!")
+			},
+			[]Arg{
+				Named("b", 24),
+				DryRun(),
+			},
+			[]interface{}{},
+			`"a" (type: int)`,
+		},
+
+		{
+			"dry run with type converter",
+			func(in struct {
+				Struct
+
+				A string
+				B int
+			}) string {
+				panic("CALLED")
+			},
+			[]Arg{
+				Named("a", 12),
+				Named("b", 2),
+				Converter(func(in int) string { panic("CALLED") }),
+				DryRun(),
+			},
+			[]interface{}{""},
+			"",
+		},
+
+		{
+			"dry run with mismatched type",
+			func(in struct {
+				Struct
+
+				A string
+				B int
+			}) string {
+				panic("CALLED")
+			},
+			[]Arg{
+				Named("a", 12),
+				Named("b", 2),
+				DryRun(),
+			},
+			[]interface{}{},
+			`"a" (type: string)`,
+		},
 	}
 
 	for _, tt := range cases {

--- a/redefine.go
+++ b/redefine.go
@@ -153,7 +153,7 @@ func (f *Func) redefineInputs(opts ...Arg) (reflect.Type, error) {
 	// function. This will recursively reach various conversion targets
 	// as necessary.
 	state := newCallState()
-	if _, err := f.reachTarget(log, &g, vertexRoot, vertexF, state, true); err != nil {
+	if _, err := f.reachTarget(log, &g, vertexRoot, vertexF, state, true, builder.dryRun); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
By using the `DryRun()` option with a call, argmapper will noop all the
converter or target function calls. This can be used to verify that
given a set of inputs, a target function can actually be reached.