### PR TITLE
Fix possible infinite loop with carefully crafted BuildFunc

### DIFF
--- a/func_test.go
+++ b/func_test.go
@@ -1287,7 +1287,7 @@ func TestBuildFunc_waypointCycle(t *testing.T) {
 		Typed("hello"),
 		ConverterFunc(f),
 	)
-	require.NoError(result.Err())
+	require.Error(result.Err())
 }
 
 func TestBuildFunc_noOutput(t *testing.T) {


### PR DESCRIPTION
This is a bit of a doozy, and I'm still not sure if its even possible to trigger without manually constructing functions with `BuildFunc` (i.e. with native Go functions). Basically: in certain cases, a carefully crafted `BuildFunc` could cause an infinite loop and eventual crash. 

The root of the issue seems to be that if SOME of the arguments are satisfied directly while OTHERS are satisfied only by a graph cycle, we visit the cycle. I fixed this by inserting a check that our path doesn't contain _ourself_ when we're attempting to resolve a graph node. This resolves the loop and returns a semi-helpful error.

