### PR TITLE
Check for cycle when attempting to reach target

### DIFF
--- a/call.go
+++ b/call.go
@@ -606,13 +606,13 @@ func (f *Func) callDirect(log hclog.Logger, argMap map[interface{}]reflect.Value
 	for _, val := range f.input.values {
 		arg, ok := argMap[graph.VertexID(val.vertex())]
 		if !ok {
-			// This should never happen because we catch unsatisfied errors
-			// earlier in the process. Because of this, we output a message
-			// that there is a bug.
-			buildErr = multierror.Append(buildErr, fmt.Errorf(
-				"argument cannot be satisfied: %s. This is a bug in "+
-					"the go-argmapper library since this shouldn't happen at this "+
-					"point.", val.String()))
+			// This can happen when a converter is able to fulfill a requirement
+			// but only part of its input requirements were provided. Since the
+			// value cannot be reached we can set an error of unsatisfied.
+			buildErr = multierror.Append(buildErr, &ErrArgumentUnsatisfied{
+				Func: f,
+				Args: []*Value{val},
+			})
 			continue
 		}
 

--- a/func_test.go
+++ b/func_test.go
@@ -519,6 +519,30 @@ func TestFuncCall(t *testing.T) {
 			"",
 		},
 
+		{
+			"multi value converters with cycle",
+			func(a int) int { return a },
+			[]Arg{
+				Typed("unused"),
+				Converter(func(v []int, _ string) int { return v[0] }),
+				Converter(func(v int, _ string) []int { return []int{v} }),
+			},
+			nil,
+			"could not be satisfied",
+		},
+
+		{
+			"multi value converters",
+			func(a int) int { return a },
+			[]Arg{
+				Typed("custom-unused"),
+				Converter(func(v []int, _ string) int { return v[0] }),
+				Converter(func(s string) []int { return []int{2} }),
+			},
+			[]interface{}{2},
+			"",
+		},
+
 		//-----------------------------------------------------------
 		// TYPE CONVERTER STRUCTS
 

--- a/func_test.go
+++ b/func_test.go
@@ -543,6 +543,18 @@ func TestFuncCall(t *testing.T) {
 			"",
 		},
 
+		{
+			"multi value converters with different types",
+			func(a int) int { return a },
+			[]Arg{
+				Typed("unused-string"),
+				Converter(func(v []int, _ string) int { return v[0] }),
+				Converter(func(x float32) []int { return []int{int(x)} }),
+			},
+			nil,
+			"could not be satisfied",
+		},
+
 		//-----------------------------------------------------------
 		// TYPE CONVERTER STRUCTS
 

--- a/redefine.go
+++ b/redefine.go
@@ -127,8 +127,9 @@ func (f *Func) redefineInputs(opts ...Arg) (reflect.Type, error) {
 	log := builder.logger
 
 	// Get our call graph
-	g, vertexRoot, vertexF, vertexI, err := f.callGraph(builder)
+	g, vertexRoot, vertexF, vertexI, convs, err := f.callGraph(builder)
 	if err != nil {
+		populateUnsatisfiedError(vertexI, convs, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
We ran into an issue where argmapper would get stuck in an infinite loop attempting to reach a required input value via converters. It occurs when two converters require more than a single input value and the output from one converter is a needed input for the other converter and vice-versa. Here's an example:

```go
package main

import (
        "fmt"

        "github.com/hashicorp/go-argmapper"
        "github.com/hashicorp/go-hclog"
)

func GetNumber(a int) int {
        return a + 40
}

func main() {
        l := hclog.New(&hclog.LoggerOptions{
                Name:  "example",
                Level: hclog.Trace,
        })

        fn, err := argmapper.NewFunc(GetNumber)
        if err != nil {
                panic(err)
        }

        args := []argmapper.Arg{
                // converters
                argmapper.Converter(func(x int, _ string) []int { return []int{x} }),
                argmapper.Converter(func(v []int, _ string) int { return v[0] }),
                // values
                argmapper.Typed("4"),
                argmapper.Typed([]int{2}),
        }

        result := fn.Call(args...)
        if result.Err() != nil {
                panic(result.Err())
        }

        fmt.Printf("Final result: %d\n", result.Out(0).(int))
}
```

This will provide the expected result (built on main):

```
...
2021-08-10T11:50:33.136-0700 [TRACE] example: final value: vertex="arg: int/" value=2
2021-08-10T11:50:33.136-0700 [TRACE] example: argument: idx=0 value=2
Final result: 42
```

If we remove the `argmapper.Typed([]int{2})` argument, we get stuck in a loop:

```
...
2021-08-10T11:54:26.017-0700 [TRACE] example: path for target: target="arg: int/" path=[root, "out: string/ (value: 4)", "arg: string/", "func: <func([]int, string) int Value>", "out: int/", "arg: int/"]
2021-08-10T11:54:26.017-0700 [TRACE] example: executing node: current=root
2021-08-10T11:54:26.017-0700 [TRACE] example: executing node: current="out: string/ (value: 4)"
2021-08-10T11:54:26.017-0700 [TRACE] example: executing node: current="arg: string/"
2021-08-10T11:54:26.017-0700 [TRACE] example: executing node: current="func: <func([]int, string) int Value>"
2021-08-10T11:54:26.017-0700 [TRACE] example: reachTarget: target="func: <func([]int, string) int Value>"
2021-08-10T11:54:26.017-0700 [TRACE] example: conv is missing an input: input="arg: []int/"
2021-08-10T11:54:26.017-0700 [TRACE] example: path for target: target="arg: []int/" path=[root, "out: string/ (value: 4)", "arg: string/", "func: <func(int, string) []int Value>", "out: []int/", "arg: []int/"]
2021-08-10T11:54:26.017-0700 [TRACE] example: executing node: current=root
2021-08-10T11:54:26.017-0700 [TRACE] example: executing node: current="out: string/ (value: 4)"
2021-08-10T11:54:26.017-0700 [TRACE] example: executing node: current="arg: string/"
2021-08-10T11:54:26.017-0700 [TRACE] example: executing node: current="func: <func(int, string) []int Value>"
2021-08-10T11:54:26.017-0700 [TRACE] example: reachTarget: target="func: <func(int, string) []int Value>"
2021-08-10T11:54:26.017-0700 [TRACE] example: conv is missing an input: input="arg: int/"
2021-08-10T11:54:26.017-0700 [TRACE] example: path for target: target="arg: int/" path=[root, "out: string/ (value: 4)", "arg: string/", "func: <func([]int, string) int Value>", "out: int/", "arg: int/"]
2021-08-10T11:54:26.017-0700 [TRACE] example: executing node: current=root
...
```

Updating the `reachTarget` function to check if the result of the current target is required in the new path and returning an unsatisfied argument error if so results in a better outcome (built on this branch):

```
2021-08-10T11:56:37.644-0700 [TRACE] example: reachTarget: target="func: <func(int) int Value>"
2021-08-10T11:56:37.644-0700 [TRACE] example: conv is missing an input: input="arg: int/"
2021-08-10T11:56:37.644-0700 [TRACE] example: path for target: target="arg: int/" path=[root, "out: string/ (value: 4)", "arg: string/", "func: <func([]int, string) int Value>", "out: int/", "arg: int/"]
2021-08-10T11:56:37.644-0700 [TRACE] example: executing node: current=root
2021-08-10T11:56:37.644-0700 [TRACE] example: executing node: current="out: string/ (value: 4)"
2021-08-10T11:56:37.644-0700 [TRACE] example: executing node: current="arg: string/"
2021-08-10T11:56:37.644-0700 [TRACE] example: executing node: current="func: <func([]int, string) int Value>"
2021-08-10T11:56:37.644-0700 [TRACE] example: reachTarget: target="func: <func([]int, string) int Value>"
2021-08-10T11:56:37.644-0700 [TRACE] example: conv is missing an input: input="arg: []int/"
2021-08-10T11:56:37.644-0700 [TRACE] example: path for target: target="arg: []int/" path=[root, "out: string/ (value: 4)", "arg: string/", "func: <func(int, string) []int Value>", "out: []int/", "arg: []int/"]
panic:
Argument to function "main.GetNumber" could not be satisfied!
```

I've updated the `callGraph` function to include the converters in the return values. This, along with the inputs, can be used to update any unsatisfied argument errors that may be returned (as was done above for the result of the `reachTarget` function). 

Another related issue with multi input converters is when a converter is missing. If we continue with the example and remove the `argmapper.Converter(func(x int, _ string) []int { return []int{x} })` we get an error back reporting a bug within the library (built on main):

```
...
2021-08-10T12:59:07.362-0700 [TRACE] example: reachTarget: target="func: <func(int) int Value>"
2021-08-10T12:59:07.362-0700 [TRACE] example: conv is missing an input: input="arg: int/"
2021-08-10T12:59:07.362-0700 [TRACE] example: path for target: target="arg: int/" path=[root, "out: string/ (value: 4)", "arg: string/", "func: <func([]int, string) int Value>", "out: int/", "arg: int/"]
2021-08-10T12:59:07.362-0700 [TRACE] example: executing node: current=root
2021-08-10T12:59:07.362-0700 [TRACE] example: executing node: current="out: string/ (value: 4)"
2021-08-10T12:59:07.362-0700 [TRACE] example: executing node: current="arg: string/"
2021-08-10T12:59:07.362-0700 [TRACE] example: executing node: current="func: <func([]int, string) int Value>"
2021-08-10T12:59:07.362-0700 [TRACE] example: reachTarget: target="func: <func([]int, string) int Value>"
2021-08-10T12:59:07.362-0700 [TRACE] example: conv satisfied
panic: 1 error occurred:
        * argument cannot be satisfied: type: []int. This is a bug in the go-argmapper library since this shouldn't happen at this point.
```

But this just appears to be an unsatisfied argument, like the others, where the available converters cannot provide the required value. If we update the error to an unsatisfied argument error, we get the same kind of information returned as we do else where with context around available values and converters (built on this branch):

```
...
2021-08-10T13:06:41.484-0700 [TRACE] example: reachTarget: target="func: <func(int) int Value>"
2021-08-10T13:06:41.484-0700 [TRACE] example: conv is missing an input: input="arg: int/"
2021-08-10T13:06:41.484-0700 [TRACE] example: path for target: target="arg: int/" path=[root, "out: string/ (value: 4)", "arg: string/", "func: <func([]int, string) int Value>", "out: int/", "arg: int/"]
2021-08-10T13:06:41.484-0700 [TRACE] example: executing node: current=root
2021-08-10T13:06:41.484-0700 [TRACE] example: executing node: current="out: string/ (value: 4)"
2021-08-10T13:06:41.485-0700 [TRACE] example: executing node: current="arg: string/"
2021-08-10T13:06:41.485-0700 [TRACE] example: executing node: current="func: <func([]int, string) int Value>"
2021-08-10T13:06:41.485-0700 [TRACE] example: reachTarget: target="func: <func([]int, string) int Value>"
2021-08-10T13:06:41.485-0700 [TRACE] example: conv satisfied
panic: 1 error occurred:
        * 
Argument to function "main.main.func1" could not be satisfied!

This means that one (or more) of the arguments to a function do not
have values that could be populated. A complete error description is below
for debugging.

==> Unsatisfiable arguments
...
```

