### PR TITLE
Avoiding panic on nil arg

### DIFF
--- a/args.go
+++ b/args.go
@@ -1,6 +1,7 @@
 package argmapper
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -42,6 +43,9 @@ func newArgBuilder(opts ...Arg) (*argBuilder, error) {
 
 	var buildErr error
 	for _, opt := range opts {
+		if opt == nil {
+			return nil, fmt.Errorf("received nil arg")
+		}
 		if err := opt(builder); err != nil {
 			buildErr = multierror.Append(buildErr, err)
 		}

--- a/args.go
+++ b/args.go
@@ -1,7 +1,7 @@
 package argmapper
 
 import (
-	"fmt"
+	"errors"
 	"reflect"
 	"strings"
 
@@ -44,7 +44,7 @@ func newArgBuilder(opts ...Arg) (*argBuilder, error) {
 	var buildErr error
 	for _, opt := range opts {
 		if opt == nil {
-			return nil, fmt.Errorf("arg cannot be nil")
+			return nil, errors.New("arg cannot be nil")
 		}
 		if err := opt(builder); err != nil {
 			buildErr = multierror.Append(buildErr, err)

--- a/args.go
+++ b/args.go
@@ -44,7 +44,7 @@ func newArgBuilder(opts ...Arg) (*argBuilder, error) {
 	var buildErr error
 	for _, opt := range opts {
 		if opt == nil {
-			return nil, fmt.Errorf("received nil arg")
+			return nil, fmt.Errorf("arg cannot be nil")
 		}
 		if err := opt(builder); err != nil {
 			buildErr = multierror.Append(buildErr, err)

--- a/func_test.go
+++ b/func_test.go
@@ -1382,6 +1382,16 @@ func TestBuildFunc_nilOutput(t *testing.T) {
 	require.NoError(f.Output().FromResult(f.Call(Named("a", 12))))
 }
 
+func TestBuildFunc_nilInput(t *testing.T) {
+	require := require.New(t)
+
+	f, err := NewFunc(func(a *int) {})
+	require.NoError(err)
+
+	// Should not panic with a nil arg
+	require.Error(f.Output().FromResult(f.Call(nil)))
+}
+
 func TestBuildFunc_errValue(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
In practice, this happened in waypoint when a nil deployment was presented as a arg [here](https://github.com/hashicorp/waypoint/blob/46dfd9e578ce8ea2435c5a0cab7157bc1d3a2ed7/internal/plugin/arg.go#L12).

Found while hunting this waypoint bug: https://github.com/hashicorp/waypoint/pull/3207